### PR TITLE
Fix calculation of SECS error variance

### DIFF
--- a/examples/plot_animation.py
+++ b/examples/plot_animation.py
@@ -57,15 +57,15 @@ B_obs = np.repeat(B_obs[:, np.newaxis, :], nobs, axis=1)
 B_obs[:, :, 0] *= 2*np.sin(np.deg2rad(obs_lat_lon_r[:, 0]))
 B_obs[:, :, 1] *= 2*np.sin(np.deg2rad(obs_lat_lon_r[:, 1]))
 
-B_var = np.ones(B_obs.shape)
+B_std = np.ones(B_obs.shape)
 # Ignore the Z component
-B_var[..., 2] = np.inf
-# Can modify the variance as a function of time to
+B_std[..., 2] = np.inf
+# Can modify the standard error as a function of time to
 # see how that changes the fits too
-# B_var[:, 0, 1] = 1 + ts
+# B_std[:, 0, 1] = 1 + ts
 
 # Fit the data, requires observation locations and data
-secs.fit(obs_loc=obs_lat_lon_r, obs_B=B_obs, obs_var=B_var)
+secs.fit(obs_loc=obs_lat_lon_r, obs_B=B_obs, obs_std=B_std)
 
 # Create prediction points
 # Extend it a little beyond the observation points (-11, 11)

--- a/tests/test_secs.py
+++ b/tests/test_secs.py
@@ -330,17 +330,17 @@ def test_fit_multi_time():
     assert_allclose(expected, secs.sec_amps)
 
 
-def test_fit_obs_var():
+def test_fit_obs_std():
     """Test that variance on observations changes the results."""
     secs = pysecs.SECS(sec_df_loc=[[1., 0., R_EARTH + 1e6],
                                    [-1., 0., R_EARTH + 1e6]])
     obs_loc = np.array([[0, 0, R_EARTH]])
     obs_B = np.ones((2, 1, 3))
     obs_B[1, :, :] *= 2
-    obs_var = np.ones(obs_B.shape)
+    obs_std = np.ones(obs_B.shape)
     # Remove the z component from the fit of the second timestep
-    obs_var[1, :, 2] = np.inf
-    secs.fit(obs_loc, obs_B, obs_var=obs_var)
+    obs_std[1, :, 2] = np.inf
+    secs.fit(obs_loc, obs_B, obs_std=obs_std)
     expected = np.array([[6.40594202e+13, -7.41421248e+13],
                          [1.382015e+14, -1.382015e+14]])
     assert_allclose(expected, secs.sec_amps, rtol=1e-6)
@@ -353,10 +353,10 @@ def test_fit_epsilon():
     obs_loc = np.array([[0, 0, R_EARTH]])
     obs_B = np.ones((2, 1, 3))
     obs_B[1, :, :] *= 2
-    obs_var = np.ones(obs_B.shape)
+    obs_std = np.ones(obs_B.shape)
     # Remove the z component from the fit of the second timestep
-    obs_var[1, :, 2] = np.inf
-    secs.fit(obs_loc, obs_B, obs_var=obs_var, epsilon=0.8)
+    obs_std[1, :, 2] = np.inf
+    secs.fit(obs_loc, obs_B, obs_std=obs_std, epsilon=0.8)
     expected = np.array([[-5.041352e+12, -5.041352e+12],
                          [1.382015e+14, -1.382015e+14]])
     assert_allclose(expected, secs.sec_amps, rtol=1e-6)


### PR DESCRIPTION
The secs.fit() function originally had an option called obs_var,
which was intended to hold independent/uncorrelated error variances
of each input channel as a function of time. For better consistency
with Pulkkinen et al. (EPS-2003), and with the USGS Geomag-IMP
package, this was modified to be obs_std, or the error standard
deviation of each input channel.

Practically speaking, this changes little, especially since the
default values were all unity, and the square root difference
between obs_var and obs_std didn't come into play. But obs_std is
arguably more mathematically "correct" for weighted least-squares.
The secs.fit() function still generates error variances for each
SEC in the form of secs.sec_amps_var, becuase this is what is
typically expected when one propogates the observation error
through to the predictions.

Note, however, that secs.sec_amps_var is not complete. Even
though we assume uncorrelated errors in the input observations,
the errors associated with the estimated SECs are not, in general,
uncorrelated. But if we stored the full error covariance matrix
for each time step, which would be required to fully and properly
map observation errors (as specified with obs_std) to the actual
SECS predictions, memory requirements would increase by a factor
equal to the number of SEC basis functions, which could quickly
become computationally prohibitive.